### PR TITLE
valve: smart broadcast flows should be a higher priority than flood flows

### DIFF
--- a/valve.py
+++ b/valve.py
@@ -346,7 +346,7 @@ class Valve(app_manager.RyuApp):
         # install broadcast/multicast rules onto datapath
         if datapath.config_default['smart_broadcast']:
             for match in matches:
-                priority = datapath.config_default['low_priority']
+                priority = datapath.config_default['high_priority']
                 cookie = datapath.config_default['cookie']
                 self.add_flow(dp, match, action, priority, cookie)
 


### PR DESCRIPTION
Note: This change is based on code inspection only and is untested so far.

Default flood flows (including controller) for each VLAN are configured
at low_priority.  Smart broadcast flows should be a higher priority so
that the more specific matches for broadcast and multicast from known
sources is unambiguously matched.
